### PR TITLE
dpscount v0.9.0 bugfix

### DIFF
--- a/dpscount/src/dpscount.lua
+++ b/dpscount/src/dpscount.lua
@@ -229,6 +229,7 @@ function NASIKO_DPSCOUNT_ON_GAME_START_3SEC()
 		Me.Loaded = true;
 		LoadSetting();
 	else
+		Me.IsCount = false;
 		Me.IsReset = true;
 	end
 


### PR DESCRIPTION
Fixed a problem that dps could not be measured after moving the map during counting.